### PR TITLE
Add arrayOfUndecodedValues to Json_decode

### DIFF
--- a/__tests__/Json_decode_test.ml
+++ b/__tests__/Json_decode_test.ml
@@ -136,6 +136,21 @@ describe "array" (fun () ->
   let open Json in
   let open! Decode in
 
+  test "arrayOfUndecodedValues" (fun () ->
+    expect @@ arrayOfUndecodedValues (Encode.array [||]) |> toEqual [||]);
+
+  test "arrayOfUndecodedValues boolean" (fun () ->
+    let x = Js.Json.parseExn {|true|} in
+    let y = Js.Json.parseExn {|1|} in
+    expect @@
+      arrayOfUndecodedValues (Js.Json.parseExn {| [true, 1] |})
+      |> toEqual [| x ; y |]);
+);
+
+describe "array" (fun () ->
+  let open Json in
+  let open! Decode in
+
   test "array" (fun () ->
     expect @@ (array int) (Encode.array [||]) |> toEqual [||]);
 

--- a/lib/js/__tests__/Json_decode_test.js
+++ b/lib/js/__tests__/Json_decode_test.js
@@ -274,6 +274,20 @@ describe("nullAs", (function () {
       }));
 
 describe("array", (function () {
+        Jest.test("arrayOfUndecodedValues", (function () {
+                return Jest.Expect[/* toEqual */12](/* array */[])(Jest.Expect[/* expect */0](Json_decode.arrayOfUndecodedValues(/* array */[])));
+              }));
+        return Jest.test("arrayOfUndecodedValues boolean", (function () {
+                      var x = JSON.parse("true");
+                      var y = JSON.parse("1");
+                      return Jest.Expect[/* toEqual */12](/* array */[
+                                    x,
+                                    y
+                                  ])(Jest.Expect[/* expect */0](Json_decode.arrayOfUndecodedValues(JSON.parse(" [true, 1] "))));
+                    }));
+      }));
+
+describe("array", (function () {
         Jest.test("array", (function () {
                 return Jest.Expect[/* toEqual */12](/* int array */[])(Jest.Expect[/* expect */0](Json_decode.array(Json_decode.$$int, /* array */[])));
               }));

--- a/lib/js/src/Json_decode.js
+++ b/lib/js/src/Json_decode.js
@@ -86,6 +86,23 @@ function nullAs(value, json) {
   }
 }
 
+function arrayOfUndecodedValues(json) {
+  if (Array.isArray(json)) {
+    var length = json.length;
+    var target = new Array(length);
+    for(var i = 0 ,i_finish = length - 1 | 0; i <= i_finish; ++i){
+      var value = json[i];
+      target[i] = value;
+    }
+    return target;
+  } else {
+    throw [
+          DecodeError,
+          "Expected array, got " + JSON.stringify(json)
+        ];
+  }
+}
+
 function array(decode, json) {
   if (Array.isArray(json)) {
     var length = json.length;
@@ -263,24 +280,25 @@ function andThen(b, a, json) {
   return Curry._2(b, Curry._1(a, json), json);
 }
 
-exports.DecodeError = DecodeError;
-exports.$$boolean   = $$boolean;
-exports.bool        = bool;
-exports.$$float     = $$float;
-exports.$$int       = $$int;
-exports.string      = string;
-exports.nullable    = nullable;
-exports.nullAs      = nullAs;
-exports.array       = array;
-exports.list        = list;
-exports.pair        = pair;
-exports.dict        = dict;
-exports.field       = field;
-exports.at          = at;
-exports.optional    = optional;
-exports.oneOf       = oneOf;
-exports.either      = either;
-exports.withDefault = withDefault;
-exports.map         = map;
-exports.andThen     = andThen;
+exports.DecodeError            = DecodeError;
+exports.$$boolean              = $$boolean;
+exports.bool                   = bool;
+exports.$$float                = $$float;
+exports.$$int                  = $$int;
+exports.string                 = string;
+exports.nullable               = nullable;
+exports.nullAs                 = nullAs;
+exports.arrayOfUndecodedValues = arrayOfUndecodedValues;
+exports.array                  = array;
+exports.list                   = list;
+exports.pair                   = pair;
+exports.dict                   = dict;
+exports.field                  = field;
+exports.at                     = at;
+exports.optional               = optional;
+exports.oneOf                  = oneOf;
+exports.either                 = either;
+exports.withDefault            = withDefault;
+exports.map                    = map;
+exports.andThen                = andThen;
 /* No side effect */

--- a/src/Json_decode.ml
+++ b/src/Json_decode.ml
@@ -48,6 +48,20 @@ let nullAs value json =
   else 
     raise @@ DecodeError ("Expected null, got " ^ Js.Json.stringify json)
 
+let arrayOfUndecodedValues json = 
+  if Js.Array.isArray json then begin
+    let source = (Obj.magic (json : Js.Json.t) : Js.Json.t array) in
+    let length = Js.Array.length source in
+    let target = _unsafeCreateUninitializedArray length in
+    for i = 0 to length - 1 do
+      let value = (Array.unsafe_get source i) in
+      Array.unsafe_set target i value;
+    done;
+    target
+  end
+  else
+    raise @@ DecodeError ("Expected array, got " ^ Js.Json.stringify json)
+  
 let array decode json = 
   if Js.Array.isArray json then begin
     let source = (Obj.magic (json : Js.Json.t) : Js.Json.t array) in

--- a/src/Json_decode.mli
+++ b/src/Json_decode.mli
@@ -150,6 +150,28 @@ val nullAs : 'a -> 'a decoder
 ]}
 *)
 
+val arrayOfUndecodedValues : Js.Json.t -> Js.Json.t array
+(** Decodes a JSON array into an [Js.Json.t array] 
+
+{b Returns} an [Js.Json.t array] if the JSON value is a JSON array. It leaves all of
+its elements encoded. Then the user can decode each individual element.
+
+@raise [DecodeError] if unsuccessful 
+
+@example {[
+  open Json
+  (* returns [| 1; 2; 3 |] *)
+  let _ = Js.Json.parseExn "[1, 2, 3]" |> Decode.arrayOfUndecodedValues
+  (* returns [| 1; 2; "c" |] *)
+  let _ = Js.Json.parseExn "[1, 2, "c"]" |> Decode.arrayOfUndecodedValues
+  (* raises DecodeError *)
+  let _ = Js.Json.parseExn "123" |> Decode.arrayOfUndecodedValues
+  (* returns None *)
+  let _ = Js.Json.parseExn "null" |> Decode.arrayOfUndecodedValues
+]}
+
+**)
+  
 val array : 'a decoder -> 'a array decoder
 (** Decodes a JSON array into an ['a array] using the given decoder on each element
     


### PR DESCRIPTION
`arrayOfUndecodedValues` takes a json value and tries to parse it into an array of json values. This is useful if you want to support decoding of sum types with two or more items like `type X = X of int * string * int`. 

I am open to suggestions for a better name for the function `arrayOfUndecodedValues`.