### PR TITLE
Migrate to composable array encoder (Phase 1)

### DIFF
--- a/__tests__/Json_decode_test.ml
+++ b/__tests__/Json_decode_test.ml
@@ -23,7 +23,7 @@ module Test = struct
     | Null -> test (prefix ^ "null") (fun () ->
       expectFn decoder Encode.null |> toThrow);
     | Array -> test (prefix ^ "array") (fun () ->
-      expectFn decoder (Encode.array [||]) |> toThrow);
+      expectFn decoder (Encode.jsonArray [||]) |> toThrow);
     | Object -> test (prefix ^ "object") (fun () ->
       expectFn decoder (Encode.object_ []) |> toThrow);
     | Bool -> test (prefix ^ "boolean") (fun () ->
@@ -137,7 +137,7 @@ describe "array" (fun () ->
   let open! Decode in
 
   test "array" (fun () ->
-    expect @@ (array int) (Encode.array [||]) |> toEqual [||]);
+    expect @@ (array int) (Encode.jsonArray [||]) |> toEqual [||]);
 
   test "array boolean" (fun () ->
     expect @@
@@ -172,7 +172,7 @@ describe "list" (fun () ->
   let open! Decode in
 
   test "array" (fun () ->
-    expect @@ (list int) (Encode.array [||]) |> toEqual []);
+    expect @@ (list int) (Encode.jsonArray [||]) |> toEqual []);
 
   test "list boolean" (fun () ->
     expect @@
@@ -332,7 +332,7 @@ describe "optional" (fun () ->
   test "null -> int" (fun () ->
     expect @@ (optional int) Encode.null |> toEqual None);
   test "array -> int" (fun () ->
-    expect @@ (optional int) (Encode.array [||]) |> toEqual None);
+    expect @@ (optional int) (Encode.jsonArray [||]) |> toEqual None);
   test "object -> int" (fun () ->
     expect @@ (optional int) (Encode.object_ []) |> toEqual None);
 
@@ -412,7 +412,7 @@ describe "withDefault" (fun () ->
   test "null" (fun () ->
     expect @@ (withDefault 0 int) Encode.null |> toEqual 0);
   test "array" (fun () ->
-    expect @@ (withDefault 0 int) (Encode.array [||]) |> toEqual 0);
+    expect @@ (withDefault 0 int) (Encode.jsonArray [||]) |> toEqual 0);
   test "object" (fun () ->
     expect @@ (withDefault 0 int) (Encode.object_ []) |> toEqual 0);
 );

--- a/__tests__/Json_encode_test.ml
+++ b/__tests__/Json_encode_test.ml
@@ -34,11 +34,14 @@ test "object_ - empty" (fun () ->
 test "object_ - simple" (fun () ->
   expect @@ object_ [("x", int 42)] |> toEqual @@ Obj.magic (Js.Dict.fromList [("x", 42)]));
 
-test "array int" (fun () ->
-  expect @@ array ([|1;2;3|] |> Array.map int) |> toEqual @@ Obj.magic [|1;2;3|]);
+test "arrayOf int" (fun () ->
+  expect @@ arrayOf int [|1;2;3|] |> toEqual @@ Obj.magic [|1;2;3|]);
 
 test "list int" (fun () ->
   expect @@ list int [1;2;3] |> toEqual @@ Obj.magic [|1;2;3|]);
+
+test "jsonArray int" (fun () ->
+  expect @@ jsonArray ([|1;2;3|] |> Array.map int) |> toEqual @@ Obj.magic [|1;2;3|]);
 
 test "stringArray" (fun () ->
   expect @@ stringArray [|"a";"b"|]  |> toEqual @@ Obj.magic [|"a";"b"|]);

--- a/examples/encode.ml
+++ b/examples/encode.ml
@@ -11,7 +11,7 @@ let _ =
 let _ =
   [| "foo"; "bar" |]
   |> Js.Array.map Json.Encode.string
-  |> Json.Encode.array
+  |> Json.Encode.jsonArray
   |> Js.Json.stringify
   |> Js.log
 

--- a/lib/js/__tests__/Json_encode_test.js
+++ b/lib/js/__tests__/Json_encode_test.js
@@ -55,12 +55,12 @@ Jest.test("object_ - simple", (function () {
                           ])));
       }));
 
-Jest.test("array int", (function () {
+Jest.test("arrayOf int", (function () {
         return Jest.Expect[/* toEqual */12](/* int array */[
                       1,
                       2,
                       3
-                    ])(Jest.Expect[/* expect */0]($$Array.map((function (prim) {
+                    ])(Jest.Expect[/* expect */0](Json_encode.arrayOf((function (prim) {
                               return prim;
                             }), /* int array */[
                             1,
@@ -85,6 +85,20 @@ Jest.test("list int", (function () {
                                 /* [] */0
                               ]
                             ]
+                          ])));
+      }));
+
+Jest.test("jsonArray int", (function () {
+        return Jest.Expect[/* toEqual */12](/* int array */[
+                      1,
+                      2,
+                      3
+                    ])(Jest.Expect[/* expect */0]($$Array.map((function (prim) {
+                              return prim;
+                            }), /* int array */[
+                            1,
+                            2,
+                            3
                           ])));
       }));
 

--- a/lib/js/src/Json_encode.js
+++ b/lib/js/src/Json_encode.js
@@ -6,17 +6,17 @@ var Curry      = require("bs-platform/lib/js/curry.js");
 var Js_dict    = require("bs-platform/lib/js/js_dict.js");
 var Js_boolean = require("bs-platform/lib/js/js_boolean.js");
 
-function nullable(encode, o) {
-  if (o) {
-    return Curry._1(encode, o[0]);
+function nullable(encode, param) {
+  if (param) {
+    return Curry._1(encode, param[0]);
   } else {
     return null;
   }
 }
 
-function withDefault(d, encode, o) {
-  if (o) {
-    return Curry._1(encode, o[0]);
+function withDefault(d, encode, param) {
+  if (param) {
+    return Curry._1(encode, param[0]);
   } else {
     return d;
   }
@@ -25,6 +25,8 @@ function withDefault(d, encode, o) {
 var bool = Js_boolean.to_js_boolean;
 
 var object_ = Js_dict.fromList;
+
+var arrayOf = $$Array.map;
 
 function list(encode, l) {
   return $$Array.of_list(List.map(encode, l));
@@ -42,5 +44,6 @@ exports.nullable    = nullable;
 exports.withDefault = withDefault;
 exports.pair        = pair;
 exports.object_     = object_;
+exports.arrayOf     = arrayOf;
 exports.list        = list;
 /* Js_dict Not a pure module */

--- a/src/Json.mli
+++ b/src/Json.mli
@@ -65,7 +65,7 @@ let _ =
 let _ =
   [| "foo", "bar" |]
   |> Js.Array.map Encode.int
-  |> Encode.array
+  |> Encode.jsonArray
   |> stringify
   |> Js.log
 ]}

--- a/src/Json_encode.ml
+++ b/src/Json_encode.ml
@@ -24,6 +24,9 @@ let object_ props: Js.Json.t =
         |> dict
 
 external array : Js.Json.t array -> Js.Json.t = "%identity"
+let arrayOf encode l =
+  l |> Array.map encode
+    |> array
 let list encode l =
   l |> List.map encode
     |> Array.of_list
@@ -31,6 +34,7 @@ let list encode l =
 
 let pair encodeA encodeB (a, b) = array [| encodeA a; encodeB b|]
 
+external jsonArray : Js.Json.t array -> Js.Json.t = "%identity"
 external stringArray : string array -> Js.Json.t = "%identity"
 external numberArray : float array -> Js.Json.t = "%identity"
 external booleanArray : Js.boolean array -> Js.Json.t = "%identity"

--- a/src/Json_encode.mli
+++ b/src/Json_encode.mli
@@ -37,14 +37,26 @@ val object_ : (string * Js.Json.t) list -> Js.Json.t
 (** [object_ props] makes a JSON objet of the [props] list of properties *)
 
 external array : Js.Json.t array -> Js.Json.t = "%identity"
-(** [array a] makes a JSON array of the [Js.Json.t array] [a] *)
+[@@deprecated "Use `jsonArray` instead"]
+(** [array a] makes a JSON array of the [Js.Json.t array] [a] 
+ *  @deprecated Use [jsonArray] instead.
+ *)
+
+val arrayOf : 'a encoder -> 'a array encoder
+(** [arrayOf encoder l] makes a JSON array of the [list] [l] using the given [encoder] 
+ *  NOTE: This will be renamed `array` once the existing and deprecated `array` function
+ *  has been removed.
+ *)
 
 val list : 'a encoder -> 'a list encoder
-(** [list encoder l] makes a JSON array of the [list] [l] using the given [encoder] *)
+(** [list encoder a] makes a JSON array of the [array] [a] using the given [encoder] *)
 
 (** The functions below are specialized for specific array type which 
     happened to be already JSON object in the BuckleScript runtime. Therefore
     they are more efficient (constant time rather than linear conversion). *) 
+
+external jsonArray : Js.Json.t array -> Js.Json.t = "%identity"
+(** [jsonArray a] makes a JSON array of the [Js.Json.t array] [a] *)
 
 external stringArray : string array -> Js.Json.t = "%identity"
 (** [stringArray a] makes a JSON array of the [string array] [a] *) 


### PR DESCRIPTION
The plan is this:
- Phase 1 (this PR)
  - Add `Encode.jsonArray` as replacement for Encode.array
  - Add composable `Encode.arrayOf`
  - Deprecate `Encode.array`
- Phase 2
  - Remove `Encode.array`
  - Rename `Encode.arrayOf` to `Encode.array`
  - Keep `Encode.arrayOf` as alias to `Encode.array`, but deprecate it
- Phase 3
  - Remove `Encode.arrayOf`

cc @cullophid Does this sound good to you?